### PR TITLE
Added new hvrVariants to correspond to Ep_35F and Ep_56A

### DIFF
--- a/hladpb1-imgtDb/data/hladpb1HypervariableRegion.xml
+++ b/hladpb1-imgtDb/data/hladpb1HypervariableRegion.xml
@@ -426,6 +426,26 @@
               <!--bead alleleName="HLA-DPB1*02:02"/-->
             </beads>
           </hvrVariant>
+          <hvrVariant variantId="5" proteinSequences="FV,FA">
+            <beads>
+              <bead alleleName="HLA-DPB1*02:01"/>
+              <bead alleleName="HLA-DPB1*03:01"/>
+              <bead alleleName="HLA-DPB1*04:02"/>
+              <bead alleleName="HLA-DPB1*06:01"/>
+              <bead alleleName="HLA-DPB1*09:01"/>
+              <bead alleleName="HLA-DPB1*10:01"/>
+              <bead alleleName="HLA-DPB1*14:01"/>
+              <bead alleleName="HLA-DPB1*17:01"/>
+              <bead alleleName="HLA-DPB1*18:01"/>
+              <bead alleleName="HLA-DPB1*19:01"/>
+              <bead alleleName="HLA-DPB1*23:01"/>
+              <bead alleleName="HLA-DPB1*20:01"/>
+              <bead alleleName="HLA-DPB1*04:01"/>
+              <bead alleleName="HLA-DPB1*28:01"/>
+              <!--bead alleleName="HLA-DPB1*31:01"/>
+              <bead alleleName="HLA-DPB1*30:01"/>
+              <bead alleleName="HLA-DPB1*105:01"/-->
+            </beads>
         </hvrVariants>
       </hypervariableRegion>
       
@@ -471,6 +491,25 @@
               <bead alleleName="HLA-DPB1*05:01"/>
               <bead alleleName="HLA-DPB1*19:01"/>
               <!--bead alleleName="HLA-DPB1*02:02"/>
+              <bead alleleName="HLA-DPB1*30:01"/-->
+            </beads>
+          </hvrVariant>
+          <hvrVariant variantId="5" proteinSequences="AAE,EAE">
+            <beads>
+              <bead alleleName="HLA-DPB1*01:01"/>
+              <bead alleleName="HLA-DPB1*04:01"/>
+              <bead alleleName="HLA-DPB1*11:01"/>
+              <bead alleleName="HLA-DPB1*13:01"/>
+              <bead alleleName="HLA-DPB1*15:01"/>
+              <bead alleleName="HLA-DPB1*23:01"/>
+              <bead alleleName="HLA-DPB1*05:01"/>
+              <bead alleleName="HLA-DPB1*19:01"/>
+              <!--bead alleleName="HLA-DPB1*26:01"/>
+              <bead alleleName="HLA-DPB1*31:01"/>
+              <bead alleleName="HLA-DPB1*40:01"/>
+              <bead alleleName="HLA-DPB1*85:01"/>
+              <bead alleleName="HLA-DPB1*107:01"/>
+              <bead alleleName="HLA-DPB1*02:02"/>
               <bead alleleName="HLA-DPB1*30:01"/-->
             </beads>
           </hvrVariant>

--- a/hladpb1-imgtDb/data/hladpb1HypervariableRegion.xml
+++ b/hladpb1-imgtDb/data/hladpb1HypervariableRegion.xml
@@ -446,6 +446,7 @@
               <bead alleleName="HLA-DPB1*30:01"/>
               <bead alleleName="HLA-DPB1*105:01"/-->
             </beads>
+          </hvrVariant>
         </hvrVariants>
       </hypervariableRegion>
       


### PR DESCRIPTION
Updated the XML to add HVR B5 and C5 created to align with Ep_35F and Ep_56A.

"We can see why there were no perfect matches for HVR_C1 (AA motif AAE at positions 55-57), but the 56A eplet had two cases that are perfect. It’s because the HVR_C4_EAE motif also carries the 56A eplet. Also, the 35F eplet is shared between HVR_B1 (“FV”), and HVR_B3 (“FA”).   If we get into combinatorics / set theory, Ep_35F = (HVR_B1_FV ∪ HVR_B3_FA) and Ep_56A = (HVR_C1_AAE ∪ HVR_C4_EAE)." 